### PR TITLE
fix: await params

### DIFF
--- a/packages/next-rest-framework/src/app-router/route.ts
+++ b/packages/next-rest-framework/src/app-router/route.ts
@@ -253,7 +253,7 @@ export const route = <T extends Record<string, RouteOperationDefinition>>(
         if (paramsSchema) {
           const { valid, errors, data } = validateSchema({
             schema: paramsSchema,
-            obj: context.params
+            obj: await context.params
           });
 
           if (!valid) {


### PR DESCRIPTION
Was getting the following error on having pathParameters:
```
{"message":"Invalid path parameters.","errors":[{"code":"invalid_type","expected":"string","received":"promise","path":[],"message":"Expected string, received promise"}]}
```
I have **not** tested this.